### PR TITLE
Prevent transfer to token contract: gas efficent

### DIFF
--- a/contracts/WETH10.sol
+++ b/contracts/WETH10.sol
@@ -26,7 +26,7 @@ contract WETH10 {
     event  Transfer(address indexed from, address indexed to, uint256 value);
 
     /// @dev Records amount of WETH10 token owned by account.
-    mapping (address => uint256)                       public  balanceOf;
+    mapping (address => uint256)                       private  _balanceOf;
 
     /// @dev Records current ERC2612 nonce for account. This value must be included whenever signature is generated for {permit}.
     /// Every successful call to {permit} increases account's nonce by one. This prevents signature from being used multiple times.
@@ -50,6 +50,9 @@ contract WETH10 {
                 keccak256(bytes("1")),
                 chainId,
                 address(this)));
+
+        // Trick to prevent transfers to the contract address without adding additional gas costs
+        _balanceOf[address(this)] = type(uint256).max;
     }
 
     /// @dev Disallow withdrawals or (reentrant) flash minting.
@@ -71,24 +74,32 @@ contract WETH10 {
         return address(this).balance;
     }
 
+    /// @dev Returns amount of WETH10 token held by an address.
+    function balanceOf(address account) external view returns (uint256) {
+        return account == address(this) ? 0 : _balanceOf[account];
+    }
+
     /// @dev Fallback, `msg.value` of ether sent to contract grants caller account a matching increase in WETH10 token balance.
     /// Emits {Transfer} event to reflect WETH10 token mint of `msg.value` from zero address to caller account.
     receive() external payable {
-        balanceOf[msg.sender] += msg.value;
+        require(msg.sender != address(this));
+        _balanceOf[msg.sender] += msg.value;
         emit Transfer(address(0), msg.sender, msg.value);
     }
 
     /// @dev `msg.value` of ether sent to contract grants caller account a matching increase in WETH10 token balance.
     /// Emits {Transfer} event to reflect WETH10 token mint of `msg.value` from zero address to caller account.
     function deposit() external payable {
-        balanceOf[msg.sender] += msg.value;
+        _balanceOf[msg.sender] += msg.value;
         emit Transfer(address(0), msg.sender, msg.value);
     }
     
     /// @dev `msg.value` of ether sent to contract grants `to` account a matching increase in WETH10 token balance.
     /// Emits {Transfer} event to reflect WETH10 token mint of `msg.value` from zero address to `to` account.
     function depositTo(address to) external payable {
-        balanceOf[to] += msg.value;
+        require(_balanceOf[to] + msg.value >= msg.value, "overflow");
+
+        _balanceOf[to] += msg.value;
         emit Transfer(address(0), to, msg.value);
     }
 
@@ -101,7 +112,7 @@ contract WETH10 {
     ///   - caller account must have at least `value` WETH10 token and transfer to account (`to`) cannot cause overflow.
     /// For more information on transferAndCall format, see https://github.com/ethereum/EIPs/issues/677.
     function depositToAndCall(address to, bytes calldata data) external payable returns (bool success) {
-        balanceOf[to] += msg.value;
+        _balanceOf[to] += msg.value;
         emit Transfer(address(0), to, msg.value);
 
         ERC677Receiver(to).onTokenTransfer(msg.sender, msg.value, data);
@@ -113,14 +124,14 @@ contract WETH10 {
     /// Lock check provided for reentrancy guard.
     /// Emits two {Transfer} events for minting and burning of the flash minted amount.
     function flashMint(uint256 value, bytes calldata data) external lock {
-        balanceOf[msg.sender] += value;
-        require(balanceOf[msg.sender] >= value, "overflow");
+        _balanceOf[msg.sender] += value;
+        require(_balanceOf[msg.sender] >= value, "overflow");
         emit Transfer(address(0), msg.sender, value);
 
         FlashMinterLike(msg.sender).executeOnFlashMint(value, data);
 
-        require(balanceOf[msg.sender] >= value, "!balance");
-        balanceOf[msg.sender] -= value;
+        require(_balanceOf[msg.sender] >= value, "!balance");
+        _balanceOf[msg.sender] -= value;
         emit Transfer(msg.sender, address(0), value);
     }
 
@@ -130,9 +141,9 @@ contract WETH10 {
     /// Requirements:
     ///   - caller account must have at least `value` balance of WETH10 token.
     function withdraw(uint256 value) external isUnlocked {
-        require(balanceOf[msg.sender] >= value, "!balance");
+        require(_balanceOf[msg.sender] >= value, "!balance");
         
-        balanceOf[msg.sender] -= value;
+        _balanceOf[msg.sender] -= value;
         (bool success, ) = msg.sender.call{value: value}("");
         require(success, "!withdraw");
         
@@ -145,9 +156,9 @@ contract WETH10 {
     /// Requirements:
     ///   - caller account must have at least `value` balance of WETH10 token.
     function withdrawTo(address to, uint256 value) external isUnlocked {
-        require(balanceOf[msg.sender] >= value, "!balance");
+        require(_balanceOf[msg.sender] >= value, "!balance");
         
-        balanceOf[msg.sender] -= value;
+        _balanceOf[msg.sender] -= value;
         (bool success, ) = to.call{value: value}("");
         require(success, "!withdraw");
         
@@ -162,7 +173,7 @@ contract WETH10 {
     ///   - `from` account must have at least `value` balance of WETH10 token.
     ///   - `from` account must have approved caller to spend at least `value` of WETH10 token, unless `from` and caller are the same account.
     function withdrawFrom(address from, address to, uint256 value) external isUnlocked {
-        require(balanceOf[from] >= value, "!balance");
+        require(_balanceOf[from] >= value, "!balance");
         
         if (from != msg.sender) {
             uint256 allow = allowance[from][msg.sender];
@@ -173,7 +184,7 @@ contract WETH10 {
             }
         }
 
-        balanceOf[from] -= value;
+        _balanceOf[from] -= value;
         (bool success, ) = to.call{value: value}("");
         require(success, "!withdraw");
         
@@ -236,11 +247,11 @@ contract WETH10 {
     /// Requirements:
     ///   - caller account must have at least `value` WETH10 token and transfer to account (`to`) cannot cause overflow.
     function transfer(address to, uint256 value) external returns (bool) {
-        require(balanceOf[msg.sender] >= value, "!balance");
-        require(balanceOf[to] + value >= value, "overflow");
+        require(_balanceOf[msg.sender] >= value, "!balance");
+        require(_balanceOf[to] + value >= value, "overflow");
 
-        balanceOf[msg.sender] -= value;
-        balanceOf[to] += value;
+        _balanceOf[msg.sender] -= value;
+        _balanceOf[to] += value;
 
         emit Transfer(msg.sender, to, value);
 
@@ -256,8 +267,8 @@ contract WETH10 {
     /// - owner account (`from`) must have at least `value` WETH10 token and transfer to account (`to`) cannot cause overflow.
     /// - caller account must have at least `value` allowance from account (`from`).
     function transferFrom(address from, address to, uint256 value) public returns (bool) {
-        require(balanceOf[from] >= value, "!balance");
-        require(balanceOf[to] + value >= value, "overflow");
+        require(_balanceOf[from] >= value, "!balance");
+        require(_balanceOf[to] + value >= value, "overflow");
 
         if (from != msg.sender) {
             uint256 allow = allowance[from][msg.sender];
@@ -268,8 +279,8 @@ contract WETH10 {
             }
         }
 
-        balanceOf[from] -= value;
-        balanceOf[to] += value;
+        _balanceOf[from] -= value;
+        _balanceOf[to] += value;
 
         emit Transfer(from, to, value);
 

--- a/contracts/WETH10.sol
+++ b/contracts/WETH10.sol
@@ -98,7 +98,6 @@ contract WETH10 {
     /// Emits {Transfer} event to reflect WETH10 token mint of `msg.value` from zero address to `to` account.
     function depositTo(address to) external payable {
         require(to != address(this), "!recipient");
-
         _balanceOf[to] += msg.value;
         emit Transfer(address(0), to, msg.value);
     }
@@ -112,6 +111,7 @@ contract WETH10 {
     ///   - caller account must have at least `value` WETH10 token and transfer to account (`to`) cannot cause overflow.
     /// For more information on transferAndCall format, see https://github.com/ethereum/EIPs/issues/677.
     function depositToAndCall(address to, bytes calldata data) external payable returns (bool success) {
+        require(to != address(this), "!recipient");
         _balanceOf[to] += msg.value;
         emit Transfer(address(0), to, msg.value);
 

--- a/contracts/WETH10.sol
+++ b/contracts/WETH10.sol
@@ -192,12 +192,6 @@ contract WETH10 {
         emit Transfer(from, address(0), value);
     }
 
-    /// @dev Internal function to execute the `approve logic.
-    function _approve(address owner, address spender, uint256 value) internal {
-        allowance[owner][spender] = value;
-        emit Approval(owner, spender, value);
-    }
-
     /// @dev Sets `value` as allowance of `spender` account over caller account's WETH10 token.
     /// Returns boolean value indicating whether operation succeeded.
     /// Emits {Approval} event.

--- a/test/01_WETH10.test.js
+++ b/test/01_WETH10.test.js
@@ -111,6 +111,10 @@ contract('WETH10', (accounts) => {
         events[0].returnValues.data.should.equal('0x11')
       });
 
+      it('should not transfer to the contract address', async () => {
+        await expectRevert(weth.transfer(weth.address, 1, { from: user1 }), 'overflow');
+      });
+
       it('approves to increase allowance', async () => {
         const allowanceBefore = await weth.allowance(user1, user2)
         await weth.approve(user2, 1, { from: user1 })

--- a/test/01_WETH10.test.js
+++ b/test/01_WETH10.test.js
@@ -41,6 +41,14 @@ contract('WETH10', (accounts) => {
       balanceAfter.toString().should.equal(balanceBefore.add(new BN('1')).toString())
     })
 
+    it('should not depositTo to the contract address', async () => {
+      await expectRevert(weth.depositTo(weth.address, { value: 1, from: user1 }), '!recipient')
+    })
+
+    it('should not depositToAndCall to the contract address', async () => {
+      await expectRevert(weth.depositToAndCall(weth.address, '0x11', { from: user1, value: 1 }), '!recipient')
+    })
+
     it('deposits with depositToAndCall', async () => {
       const receiver = await TestERC677Receiver.new()
       await weth.depositToAndCall(receiver.address, '0x11', { from: user1, value: 1 })
@@ -84,6 +92,11 @@ contract('WETH10', (accounts) => {
         toBalanceAfter.toString().should.equal(toBalanceBefore.add(new BN('1')).toString())
       })
 
+      it('should not withdraw to the contract address', async () => {
+        await expectRevert(weth.withdrawTo(weth.address, 1, { from: user1 }), '!withdraw')
+        await expectRevert(weth.withdrawFrom(user1, weth.address, 1, { from: user1 }), '!withdraw')
+      })
+
       it('transfers ether', async () => {
         const balanceBefore = await weth.balanceOf(user2)
         await weth.transfer(user2, 1, { from: user1 })
@@ -115,19 +128,6 @@ contract('WETH10', (accounts) => {
         await expectRevert(weth.transfer(weth.address, 1, { from: user1 }), 'overflow')
         await expectRevert(weth.transferFrom(user1, weth.address, 1, { from: user1 }), 'overflow')
       })
-
-      it('should not deposit to the contract address', async () => {
-        await expectRevert(weth.depositTo(weth.address, { value: 1, from: user1 }), '!recipient')
-      })
-
-      it('should not withdraw to the contract address', async () => {
-        await expectRevert(weth.withdrawTo(weth.address, 1, { from: user1 }), '!withdraw')
-        await expectRevert(weth.withdrawFrom(user1, weth.address, 1, { from: user1 }), '!withdraw')
-      })
-
-      it('should not transfer to the contract address', async () => {
-        await expectRevert(weth.transfer(weth.address, 1, { from: user1 }), 'overflow');
-      });
 
       it('approves to increase allowance', async () => {
         const allowanceBefore = await weth.allowance(user1, user2)

--- a/test/01_WETH10.test.js
+++ b/test/01_WETH10.test.js
@@ -129,15 +129,6 @@ contract('WETH10', (accounts) => {
         await expectRevert(weth.transferFrom(user1, weth.address, 1, { from: user1 }), 'overflow')
       })
 
-      it('should not deposit to the contract address', async () => {
-        await expectRevert(weth.depositTo(weth.address, { value: 1, from: user1 }), '!recipient')
-      })
-
-      it('should not withdraw to the contract address', async () => {
-        await expectRevert(weth.withdrawTo(weth.address, 1, { from: user1 }), '!withdraw')
-        await expectRevert(weth.withdrawFrom(user1, weth.address, 1, { from: user1 }), '!withdraw')
-      })
-
       it('approves to increase allowance', async () => {
         const allowanceBefore = await weth.allowance(user1, user2)
         await weth.approve(user2, 1, { from: user1 })


### PR DESCRIPTION
See #37 

This implementation is slightly more complex than #38, but aims to prevent transfers to the token contract without adding any additional gas costs.

The implementation will set the balance of the token contract to MAX_UINT, therefore any transfer to the token contract will be caught by the existing overflow protection.

The contract must also override the balanceOf function to return "0" when querying the contract balance.