### PR TITLE
Alternative flashMint implementation

### DIFF
--- a/contracts/FlashMinter.sol
+++ b/contracts/FlashMinter.sol
@@ -5,6 +5,7 @@ interface FlashMinterLike {
     function balanceOf(address) external returns (uint256);
     function executeOnFlashMint(uint256 value, bytes calldata data) external;
     function flashMint(uint256, bytes calldata) external;
+    function flashReturn(uint256 value) external;
 }
 
 contract FlashMinter {
@@ -17,6 +18,7 @@ contract FlashMinter {
         (address target) = abi.decode(data, (address)); // Use this to unpack arbitrary data
         flashData = target;
         flashBalance = FlashMinterLike(target).balanceOf(address(this));
+        FlashMinterLike(target).flashReturn(value);
     }
 
     function flashMint(address target, uint256 value) external {


### PR DESCRIPTION
This is an alternative to the existing flashMint implementation in #28

This implementation has the following advantages:

1. Removes locks, making the contract simpler and more gas efficient
2. Allows multiple, simultaneous flashMints
3. Allows access to all functions during the flashMint. This means users can withdraw ETH, effectively allowing flashLoans of ETH

Gas efficiency for the flashMint should be similar, possibly 1 or 2 new SLOADs