### PR TITLE
Remove flash loan locks

### DIFF
--- a/contracts/tests/TestFlashMinter.sol
+++ b/contracts/tests/TestFlashMinter.sol
@@ -5,12 +5,12 @@ interface FlashMintableLike {
     function flashMint(uint256, bytes calldata) external;
     function balanceOf(address) external returns (uint256);
     function withdraw(uint256) external;
-    function withdrawTo(address, uint256) external;
-    function withdrawFrom(address, address, uint256) external;
+    function transfer(address, uint256) external;
+    function deposit() payable external;
 }
 
 contract TestFlashMinter {
-    enum Action {BALANCE, FLASH, WITHDRAW, WITHDRAW_TO, WITHDRAW_FROM}
+    enum Action {NORMAL, STEAL, WITHDRAW, REENTER}
 
     uint256 public flashBalance;
     uint256 public flashValue;
@@ -22,42 +22,40 @@ contract TestFlashMinter {
         flashValue = value;
         (Action action, address target) = abi.decode(data, (Action, address)); // Use this to unpack arbitrary data
         flashData = target;  // Here msg.sender is the weth contract, and target is the user
-        if (action == Action.BALANCE) {
+        if (action == Action.NORMAL) {
             flashBalance = FlashMintableLike(msg.sender).balanceOf(address(this));
-        } else if (action == Action.FLASH) {
-            flashMintReentry(msg.sender, value);
         } else if (action == Action.WITHDRAW) {
             FlashMintableLike(msg.sender).withdraw(value);
-        } else if (action == Action.WITHDRAW_TO) {
-            FlashMintableLike(msg.sender).withdrawTo(target, value);
-        } else if (action == Action.WITHDRAW_FROM) {
-            FlashMintableLike(msg.sender).withdrawFrom(target, target, value);
+            flashBalance = address(this).balance;
+            FlashMintableLike(msg.sender).deposit{ value: value }();
+        } else if (action == Action.STEAL) {
+            FlashMintableLike(msg.sender).transfer(address(1), value);
+        } else if (action == Action.REENTER) {
+            flashMint(msg.sender, value * 2);
         }
     }
 
     function flashMint(address target, uint256 value) public {
         // Use this to pack arbitrary data to `executeOnFlashMint`
-        bytes memory data = abi.encode(Action.BALANCE, msg.sender); // Here msg.sender is the user, and target is the weth contract
-        FlashMintableLike(target).flashMint(value, data);
-    }
-
-    function flashMintReentry(address target, uint256 value) public {
-        bytes memory data = abi.encode(Action.FLASH, msg.sender); // Here msg.sender is the user, and target is the weth contract
+        bytes memory data = abi.encode(Action.NORMAL, msg.sender); // Here msg.sender is the user, and target is the weth contract
         FlashMintableLike(target).flashMint(value, data);
     }
 
     function flashMintAndWithdraw(address target, uint256 value) public {
+        // Use this to pack arbitrary data to `executeOnFlashMint`
         bytes memory data = abi.encode(Action.WITHDRAW, msg.sender); // Here msg.sender is the user, and target is the weth contract
         FlashMintableLike(target).flashMint(value, data);
     }
 
-    function flashMintAndWithdrawTo(address target, uint256 value) public {
-        bytes memory data = abi.encode(Action.WITHDRAW_TO, msg.sender); // Here msg.sender is the user, and target is the weth contract
+    function flashMintAndSteal(address target, uint256 value) public {
+        // Use this to pack arbitrary data to `executeOnFlashMint`
+        bytes memory data = abi.encode(Action.STEAL, msg.sender); // Here msg.sender is the user, and target is the weth contract
         FlashMintableLike(target).flashMint(value, data);
     }
 
-    function flashMintAndWithdrawFrom(address target, uint256 value) public {
-        bytes memory data = abi.encode(Action.WITHDRAW_FROM, msg.sender); // Here msg.sender is the user, and target is the weth contract
+    function flashMintAndReenter(address target, uint256 value) public {
+        // Use this to pack arbitrary data to `executeOnFlashMint`
+        bytes memory data = abi.encode(Action.REENTER, msg.sender); // Here msg.sender is the user, and target is the weth contract
         FlashMintableLike(target).flashMint(value, data);
     }
 }

--- a/test/02_WETH10_Flash.test.js
+++ b/test/02_WETH10_Flash.test.js
@@ -14,8 +14,8 @@ contract('WETH10 - Flash Minting', (accounts) => {
     flash = await TestFlashMinter.new({ from: deployer })
   })
 
-  it('flash mints', async () => {
-    flash.flashMint(weth.address, 1, { from: deployer })
+  it('should do a simple flash mint', async () => {
+    await flash.flashMint(weth.address, 1, { from: deployer })
 
     const balanceAfter = await weth.balanceOf(deployer)
     balanceAfter.toString().should.equal(new BN('0').toString())
@@ -27,19 +27,30 @@ contract('WETH10 - Flash Minting', (accounts) => {
     flashData.toString().should.equal(deployer)
   })
 
-  it('cannot reenter during a flash mint', async () => {
-    await expectRevert(flash.flashMintReentry(weth.address, 1, { from: deployer }), 'locked')
+  it('should not steal a flash mint', async () => {
+    await expectRevert(
+      flash.flashMintAndSteal(weth.address, 1, { from: deployer }),
+      '!balance'
+    )
   })
 
-  it('cannot withdraw during a flash mint', async () => {
-    await expectRevert(flash.flashMintAndWithdraw(weth.address, 1, { from: deployer }), 'locked')
+  it('should do two nested flash loans', async () => {
+    await flash.flashMintAndReenter(weth.address, 1, { from: deployer })
+
+    const flashBalance = await flash.flashBalance()
+    flashBalance.toString().should.equal('3')
   })
 
-  it('cannot withdrawTo during a flash mint', async () => {
-    await expectRevert(flash.flashMintAndWithdrawTo(weth.address, 1, { from: deployer }), 'locked')
-  })
+  describe('with a non-zero WETH supply', () => {
+    beforeEach(async () => {
+      await weth.deposit({ from: deployer, value: 10 })
+    })
 
-  it('cannot withdrawFrom during a flash mint', async () => {
-    await expectRevert(flash.flashMintAndWithdrawFrom(weth.address, 1, { from: deployer }), 'locked')
+    it('should flash mint, withdraw & deposit', async () => {
+      await flash.flashMintAndWithdraw(weth.address, 1, { from: deployer })
+
+      const flashBalance = await flash.flashBalance()
+      flashBalance.toString().should.equal('1')
+    })
   })
 })


### PR DESCRIPTION
So far, I haven't been seen any evidence of attacks that come from withdrawing ETH during a flash loan, or recursive/nested flash loans.

Furthermore, the lock modifiers add additional gas costs to every withdraw call. Therefore, I've removed these locks.

This PR also includes some additional test cases for flash loans:

1. Successfully withdrawing ETH and redepositing
2. Unsuccessfully calling flashMint without repaying it
3. Calling flashMint recursively