### PR TITLE
Rename FlashMinter to TestFlashMinter

### DIFF
--- a/contracts/tests/TestFlashMinter.sol
+++ b/contracts/tests/TestFlashMinter.sol
@@ -9,7 +9,7 @@ interface FlashMintableLike {
     function withdrawFrom(address, address, uint256) external;
 }
 
-contract FlashMinter {
+contract TestFlashMinter {
     enum Action {BALANCE, FLASH, WITHDRAW, WITHDRAW_TO, WITHDRAW_FROM}
 
     uint256 public flashBalance;

--- a/test/02_WETH10_Flash.test.js
+++ b/test/02_WETH10_Flash.test.js
@@ -1,5 +1,5 @@
 const WETH10 = artifacts.require('WETH10')
-const FlashMinter = artifacts.require('FlashMinter')
+const TestFlashMinter = artifacts.require('TestFlashMinter')
 
 const { BN, expectRevert } = require('@openzeppelin/test-helpers')
 require('chai').use(require('chai-as-promised')).should()
@@ -11,7 +11,7 @@ contract('WETH10 - Flash Minting', (accounts) => {
 
   beforeEach(async () => {
     weth = await WETH10.new({ from: deployer })
-    flash = await FlashMinter.new({ from: deployer })
+    flash = await TestFlashMinter.new({ from: deployer })
   })
 
   it('flash mints', async () => {


### PR DESCRIPTION
Just to keep the repo clean and organized, I've renamed FlashMinter and moved it to the test directory